### PR TITLE
Add ability to limit included lines

### DIFF
--- a/bin/cvCompile
+++ b/bin/cvCompile
@@ -18,9 +18,10 @@ function doInclude
 {
     local file="$1"
     local contextOverride="$2"
+    local head="$3"
     local startingContext="$context"
 
-    if [ "$contextOverride" == '-->' ]; then
+    if [ "$contextOverride" == '-->' ] || [ "$contextOverride" == '.' ]; then
         contextOverride=''
     fi
 
@@ -30,6 +31,10 @@ function doInclude
         fi
 
         file="$(echo "$file" | sed "s#~\!context\!~#$context#g")"
+    fi
+
+    if [ "$head" == '-->' ]; then
+        head=''
     fi
 
     if [ ! -e "$file" ]; then
@@ -51,9 +56,21 @@ function doInclude
         else
             echo "$line"
         fi
-    done < "$file"
+    done < <(readFile "$file" "$head")
 
     context="$startingContext"
+}
+
+function readFile
+{
+    local fileName="$1"
+    local head="$2"
+
+    if [ "$head" == '' ]; then
+        cat "$fileName"
+    else
+        head -n"$head" "$fileName"
+    fi
 }
 
 function doForEach
@@ -96,7 +113,7 @@ function doCommand
 
     case "$command" in
         'include')
-            doInclude "$p1" "$p2"
+            doInclude "$p1" "$p2" "$p3"
         ;;
         'forEach')
             doForEach "$p1" "$p2" "$p3" "$p4" "$p5" "$p6" "$p7" "$p8"
@@ -131,6 +148,7 @@ function doCompile
 
     doInclude "../$variantFile" >> "$outFile"
 
+    echo "Finished \"$name\"."
     cd ..
 }
 
@@ -144,8 +162,9 @@ fi
 # Figure out what to compile.
 if [ "$1" == '' ]; then
     while read variant; do
-        doCompile "$variant"
+        doCompile "$variant" &
     done < <(cvList)
+    wait
 else
     doCompile "$1"
 fi

--- a/doc/usingIt.md
+++ b/doc/usingIt.md
@@ -88,6 +88,20 @@ Eg
 <!-- do include src/intro/longIntro.md -->
 ```
 
+### include while limiting the number of lines
+
+This is useful when you have a section that is too big for one format, but you want all of the lines on some other layouts.
+
+Syntax
+
+```html
+<!-- do include src/skills/keySkills.md . 15 -->
+```
+
+Here we are only including the first 15 lines of keySkills.md.
+
+The `.` is the context. So you can still provide that just like you would with the [include with context
+](#include-with-context) section above, if you want to .
 
 ### forEach
 


### PR DESCRIPTION
This is useful for when you have a section where not everything is essential, but still has value. So it's a great place to compact things when a variant needs to shrink, but you don't want to lose that detail on other variants.