### PR TITLE
Separate out specific builds

### DIFF
--- a/bin/cvBuild
+++ b/bin/cvBuild
@@ -20,6 +20,19 @@ if [ ! -e "cvData" ]; then
     exit 1
 fi
 
+# Separate numbering.
+# Custom CVs don't need to follow the same numbering as everything else. However anything non-custom should share the same numbering to avoid potentially going back in time.
+if [ "$1" != '' ]; then
+    if ! cvList | grep -q "$1"; then
+        if cvList custom | grep -q "$1"; then
+            numberingDir="cvData/specificNumbering"
+            mkdir -p "$numberingDir"
+            numberingConfig="$numberingDir/$1"
+        fi
+    fi
+fi
+
+
 # Disable cvBuildFile's auto numbering.
 export CV_NO_AUTO=1
 


### PR DESCRIPTION
Makes the CV version numbering separate per custom build. The generic builds still share a common numbering to avoid potentially sending an old version by accident.