### PR TITLE
Send specific variants to custom destinations

### DIFF
--- a/bin/cvBuildFile
+++ b/bin/cvBuildFile
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Build a specific file.
-# Copyright (C) 2023  Kevin Sandom
+# Copyright (C) 2023-2024  Kevin Sandom
 
 inFile="${1:-cvData/cvData.md}"
 tmpFile="/tmp/$$-cv.md"
@@ -92,40 +92,39 @@ else
   echo "$variant: File out: \"$outFile\" ."
 fi
 
+function handleOldVersions
+{
+  # Move old versions out of the way.
+  local directory="$1"
+  local startDirectory="$(pwd)"
+  local variant="$2"
+
+  cd "$directory"
+  mkdir -pv old
+  mv -v *-$variant.pdf* old
+  cd "$startDirectory"
+}
 
 # Change destination if it's custom.
 isCustom "$variant"
 custom="$?"
-
-if [ "$custom" == "0" ]; then
+if [ -e "outs/$variant" ]; then
+  outFile="outs/$variant/$outFile"
+  handleOldVersions "outs/$variant" "$variant"
+elif [ "$custom" == "0" ]; then
   outFile="custom/$outFile"
   echo "$variant: Is custom. New destination: $outFile"
   mkdir -p custom
+  handleOldVersions custom "$variant"
 else
   echo "$variant: Is not custom."
+  handleOldVersions . "$variant"
 fi
 
 
 # Put in variables.
 echo "$variant: Preparing input: $tmpFile."
 sed 's/~!today!~/'$name'/g;s/~!whoNatural!~/'"$whoNatural"'/g;s/~!whoCamel!~/'"$whoCamel"'/g;s/~!variant!~/'"${variant^}"'/g' "$inFile" > "$tmpFile"
-
-
-# Move old versions out of the way.
-if [ "$custom" == "0" ]; then
-  cd custom
-  mkdir -p old
-  echo "$variant: Moving old custom version to old/."
-  mv -v *-$variant.pdf* old
-  cd ..
-else
-  if [ "$variant" != '' ]; then
-    mkdir -p old
-    echo "$variant: Moving old versions to old/."
-    mv -v *-$variant.pdf* old
-  fi
-fi
-
 
 
 # Generate the PDF.

--- a/bin/cvCompile
+++ b/bin/cvCompile
@@ -85,7 +85,7 @@ function doHighlightFilterInclude
 
     local filter="$(getFilter "$rawFilterName")"
     local surround='\(\ \|-\|\[\|\]\|,\|:\)'
-    doInclude "$file" "$contextOverride" "$head" | sed "s/$surround\($filter\)$surround/\1**\2**\3/g"
+    doInclude "$file" "$contextOverride" "$head" | sed "s|$surround\($filter\)$surround|\1**\2**\3|g"
 }
 
 function noComments
@@ -214,10 +214,14 @@ function limit
 {
     local head="$1"
 
-    if [ "$head" == '' ]; then
+    if [ "$head" == '' ] || [ "$head" == '-->' ] ; then
         cat -
     else
-        head -n"$head"
+        if [ "$head" -gt 0 ]; then
+            head -n"$head"
+        else
+            cat -
+        fi
     fi
 }
 

--- a/bin/cvGenerateBase
+++ b/bin/cvGenerateBase
@@ -20,7 +20,7 @@ fi
 mkdir -pv cvData
 cd cvData
 
-mkdir -pv src variant compiled custom
+mkdir -pv src variant compiled custom outs
 
 echo
 echo "Copying example files."

--- a/bin/cvList
+++ b/bin/cvList
@@ -20,6 +20,15 @@ function listSrc
     find | cut -b3- | grep ^src | sort
 }
 
+function filter
+{
+    if [ "$1" == '' ]; then
+        cat -
+    else
+        grep -i "$1"
+    fi
+}
+
 function showHelp
 {
     echo -e "List stuff.\nHere is some stuff that you can list:\n"
@@ -37,19 +46,22 @@ fi
 # Figure out what to get.
 case "$1" in
     "variants") # List available variants.
-        listVariants
+        listVariants | filter "$2"
     ;;
     "custom") # List includable files in src/.
-        listCustom
+        listCustom | filter "$2"
     ;;
     "src") # List includable files in src/.
-        listSrc
+        listSrc | filter "$2"
     ;;
     "help") # Show this help.
         showHelp
     ;;
-    *)
+    "") # Default to showing the variants.
         listVariants
+    ;;
+    *) # Search for custom CVs using the provided parameter.
+        listCustom | filter "$1"
     ;;
 esac
 

--- a/doc/howTo/customDestinations.md
+++ b/doc/howTo/customDestinations.md
@@ -1,0 +1,64 @@
+# How to send specific variants to custom destinations
+
+Without doing anything, variants will be built in the current directory, and custom variants will be built in the custom directory.
+
+But if you put a symlink to your desired directory within the `outs/` directory, and name it exactly the same as a specific variant, that variant will always be built in that destination directory.
+
+## Why?
+
+Example: In my build setup, I have a directory per job that I want to apply for. I want the built CV to go directly into that directory, and have old versions managed in there as well.
+
+This will also work for normal variants. Although I haven't yet thought of a good use-case for that.
+
+## How?
+
+Let's find a [custom CV](buildCustomCVs.md) to use:
+
+```
+$ cvList custom
+CompanyA-Role1
+CompanyB-Role1
+CompanyB-Role2
+```
+
+Let's send `CompanyB-Role2` to the directory dedicated to that role:
+
+```
+$ mkdir -p outs
+$ cd outs
+$ ln -s ~/Documents/jobs/CompanyB-Role2 .
+$ ls -l
+total 0
+lrwxrwxrwx 1 ksandom users 43 Jun 12 11:00 CompanyB-Role2 -> /home/ksandom/Documents/jobs/CompanyB-Role2
+```
+
+It doesn't matter what the destination directory is called, but the symlink has to exactly match the variant name. Eg, this would work:
+
+```
+$ ln -s ~/Documents/jobs/somethingElse CompanyB-Role2
+$ ls -l
+total 0
+lrwxrwxrwx 1 ksandom users 43 Jun 12 11:00 CompanyB-Role2 -> /home/ksandom/Documents/jobs/somethingElse
+```
+
+But this would not work:
+
+```
+$ ln -s ~/Documents/jobs/CompanyB-Role2 somethingElse
+$ ls -l
+total 0
+lrwxrwxrwx 1 ksandom users 43 Jun 12 11:00 somethingElse -> /home/ksandom/Documents/jobs/CompanyB-Role2
+```
+
+The above example fails because `somethingElse` does not match the variant name `CompanyB-Role2`.
+
+And this would not work:
+
+```
+$ ln -s ~/Documents/jobs/CompanyB-Role2 CompanyB-role2
+$ ls -l
+total 0
+lrwxrwxrwx 1 ksandom users 43 Jun 12 11:00 CompanyB-role2 -> /home/ksandom/Documents/jobs/CompanyB-Role2
+```
+
+The above example fails because `CompanyB-role2` does not match the variant name `CompanyB-Role2`.

--- a/template/util/col05.md
+++ b/template/util/col05.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 5%. -->
+
+::: {.column width="5%" valign="t"}

--- a/template/util/col06.md
+++ b/template/util/col06.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 6%. -->
+
+::: {.column width="6%" valign="t"}

--- a/template/util/col07.md
+++ b/template/util/col07.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 7%. -->
+
+::: {.column width="7%" valign="t"}

--- a/template/util/col08.md
+++ b/template/util/col08.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 8%. -->
+
+::: {.column width="8%" valign="t"}

--- a/template/util/col09.md
+++ b/template/util/col09.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 9%. -->
+
+::: {.column width="9%" valign="t"}

--- a/template/util/col10.md
+++ b/template/util/col10.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 10%. -->
+
+::: {.column width="10%" valign="t"}

--- a/template/util/col11.md
+++ b/template/util/col11.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 11%. -->
+
+::: {.column width="11%" valign="t"}

--- a/template/util/col12.md
+++ b/template/util/col12.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 12%. -->
+
+::: {.column width="12%" valign="t"}

--- a/template/util/col13.md
+++ b/template/util/col13.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 13%. -->
+
+::: {.column width="13%" valign="t"}

--- a/template/util/col14.md
+++ b/template/util/col14.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 14%. -->
+
+::: {.column width="14%" valign="t"}

--- a/template/util/col15.md
+++ b/template/util/col15.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 15%. -->
+
+::: {.column width="15%" valign="t"}

--- a/template/util/col16.md
+++ b/template/util/col16.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 16%. -->
+
+::: {.column width="16%" valign="t"}

--- a/template/util/col17.md
+++ b/template/util/col17.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 17%. -->
+
+::: {.column width="17%" valign="t"}

--- a/template/util/col18.md
+++ b/template/util/col18.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 18%. -->
+
+::: {.column width="18%" valign="t"}

--- a/template/util/col19.md
+++ b/template/util/col19.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 19%. -->
+
+::: {.column width="19%" valign="t"}

--- a/template/util/col20.md
+++ b/template/util/col20.md
@@ -1,4 +1,4 @@
-<!-- Copyright (C) 2023  Kevin Sandom -->
-<!-- Begin a new column. -->
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 20%. -->
 
 ::: {.column width="20%" valign="t"}

--- a/template/util/col21.md
+++ b/template/util/col21.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 21%. -->
+
+::: {.column width="21%" valign="t"}

--- a/template/util/col22.md
+++ b/template/util/col22.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 22%. -->
+
+::: {.column width="22%" valign="t"}

--- a/template/util/col23.md
+++ b/template/util/col23.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 23%. -->
+
+::: {.column width="23%" valign="t"}

--- a/template/util/col24.md
+++ b/template/util/col24.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 24%. -->
+
+::: {.column width="24%" valign="t"}

--- a/template/util/col25.md
+++ b/template/util/col25.md
@@ -1,4 +1,4 @@
-<!-- Copyright (C) 2023  Kevin Sandom -->
-<!-- Begin a new column. -->
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 25%. -->
 
 ::: {.column width="25%" valign="t"}

--- a/template/util/col26.md
+++ b/template/util/col26.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 26%. -->
+
+::: {.column width="26%" valign="t"}

--- a/template/util/col27.md
+++ b/template/util/col27.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 27%. -->
+
+::: {.column width="27%" valign="t"}

--- a/template/util/col28.md
+++ b/template/util/col28.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 28%. -->
+
+::: {.column width="28%" valign="t"}

--- a/template/util/col29.md
+++ b/template/util/col29.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 29%. -->
+
+::: {.column width="29%" valign="t"}

--- a/template/util/col30.md
+++ b/template/util/col30.md
@@ -1,4 +1,4 @@
-<!-- Copyright (C) 2023  Kevin Sandom -->
-<!-- Begin a new column. -->
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 30%. -->
 
 ::: {.column width="30%" valign="t"}

--- a/template/util/col31.md
+++ b/template/util/col31.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 31%. -->
+
+::: {.column width="31%" valign="t"}

--- a/template/util/col32.md
+++ b/template/util/col32.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 32%. -->
+
+::: {.column width="32%" valign="t"}

--- a/template/util/col33.md
+++ b/template/util/col33.md
@@ -1,4 +1,4 @@
-<!-- Copyright (C) 2023  Kevin Sandom -->
-<!-- Begin a new column. -->
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 33%. -->
 
 ::: {.column width="33%" valign="t"}

--- a/template/util/col34.md
+++ b/template/util/col34.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 34%. -->
+
+::: {.column width="34%" valign="t"}

--- a/template/util/col35.md
+++ b/template/util/col35.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 35%. -->
+
+::: {.column width="35%" valign="t"}

--- a/template/util/col36.md
+++ b/template/util/col36.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 36%. -->
+
+::: {.column width="36%" valign="t"}

--- a/template/util/col37.md
+++ b/template/util/col37.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 37%. -->
+
+::: {.column width="37%" valign="t"}

--- a/template/util/col38.md
+++ b/template/util/col38.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 38%. -->
+
+::: {.column width="38%" valign="t"}

--- a/template/util/col39.md
+++ b/template/util/col39.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 39%. -->
+
+::: {.column width="39%" valign="t"}

--- a/template/util/col40.md
+++ b/template/util/col40.md
@@ -1,4 +1,4 @@
-<!-- Copyright (C) 2023  Kevin Sandom -->
-<!-- Begin a new column. -->
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 40%. -->
 
 ::: {.column width="40%" valign="t"}

--- a/template/util/col41.md
+++ b/template/util/col41.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 41%. -->
+
+::: {.column width="41%" valign="t"}

--- a/template/util/col42.md
+++ b/template/util/col42.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 42%. -->
+
+::: {.column width="42%" valign="t"}

--- a/template/util/col43.md
+++ b/template/util/col43.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 43%. -->
+
+::: {.column width="43%" valign="t"}

--- a/template/util/col44.md
+++ b/template/util/col44.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 44%. -->
+
+::: {.column width="44%" valign="t"}

--- a/template/util/col45.md
+++ b/template/util/col45.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 45%. -->
+
+::: {.column width="45%" valign="t"}

--- a/template/util/col46.md
+++ b/template/util/col46.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 46%. -->
+
+::: {.column width="46%" valign="t"}

--- a/template/util/col47.md
+++ b/template/util/col47.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 47%. -->
+
+::: {.column width="47%" valign="t"}

--- a/template/util/col48.md
+++ b/template/util/col48.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 48%. -->
+
+::: {.column width="48%" valign="t"}

--- a/template/util/col49.md
+++ b/template/util/col49.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 49%. -->
+
+::: {.column width="49%" valign="t"}

--- a/template/util/col50.md
+++ b/template/util/col50.md
@@ -1,4 +1,4 @@
-<!-- Copyright (C) 2023  Kevin Sandom -->
-<!-- Begin a new column. -->
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 50%. -->
 
 ::: {.column width="50%" valign="t"}

--- a/template/util/col51.md
+++ b/template/util/col51.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 51%. -->
+
+::: {.column width="51%" valign="t"}

--- a/template/util/col52.md
+++ b/template/util/col52.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 52%. -->
+
+::: {.column width="52%" valign="t"}

--- a/template/util/col53.md
+++ b/template/util/col53.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 53%. -->
+
+::: {.column width="53%" valign="t"}

--- a/template/util/col54.md
+++ b/template/util/col54.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 54%. -->
+
+::: {.column width="54%" valign="t"}

--- a/template/util/col55.md
+++ b/template/util/col55.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 55%. -->
+
+::: {.column width="55%" valign="t"}

--- a/template/util/col56.md
+++ b/template/util/col56.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 56%. -->
+
+::: {.column width="56%" valign="t"}

--- a/template/util/col57.md
+++ b/template/util/col57.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 57%. -->
+
+::: {.column width="57%" valign="t"}

--- a/template/util/col58.md
+++ b/template/util/col58.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 58%. -->
+
+::: {.column width="58%" valign="t"}

--- a/template/util/col59.md
+++ b/template/util/col59.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 59%. -->
+
+::: {.column width="59%" valign="t"}

--- a/template/util/col60.md
+++ b/template/util/col60.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 60%. -->
+
+::: {.column width="60%" valign="t"}

--- a/template/util/col61.md
+++ b/template/util/col61.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 61%. -->
+
+::: {.column width="61%" valign="t"}

--- a/template/util/col62.md
+++ b/template/util/col62.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 62%. -->
+
+::: {.column width="62%" valign="t"}

--- a/template/util/col63.md
+++ b/template/util/col63.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 63%. -->
+
+::: {.column width="63%" valign="t"}

--- a/template/util/col64.md
+++ b/template/util/col64.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 64%. -->
+
+::: {.column width="64%" valign="t"}

--- a/template/util/col65.md
+++ b/template/util/col65.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 65%. -->
+
+::: {.column width="65%" valign="t"}

--- a/template/util/col66.md
+++ b/template/util/col66.md
@@ -1,4 +1,4 @@
-<!-- Copyright (C) 2023  Kevin Sandom -->
-<!-- Begin a new column. -->
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 66%. -->
 
 ::: {.column width="66%" valign="t"}

--- a/template/util/col67.md
+++ b/template/util/col67.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 67%. -->
+
+::: {.column width="67%" valign="t"}

--- a/template/util/col68.md
+++ b/template/util/col68.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 68%. -->
+
+::: {.column width="68%" valign="t"}

--- a/template/util/col69.md
+++ b/template/util/col69.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 69%. -->
+
+::: {.column width="69%" valign="t"}

--- a/template/util/col70.md
+++ b/template/util/col70.md
@@ -1,4 +1,4 @@
-<!-- Copyright (C) 2023  Kevin Sandom -->
-<!-- Begin a new column. -->
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 70%. -->
 
 ::: {.column width="70%" valign="t"}

--- a/template/util/col71.md
+++ b/template/util/col71.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 71%. -->
+
+::: {.column width="71%" valign="t"}

--- a/template/util/col72.md
+++ b/template/util/col72.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 72%. -->
+
+::: {.column width="72%" valign="t"}

--- a/template/util/col73.md
+++ b/template/util/col73.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 73%. -->
+
+::: {.column width="73%" valign="t"}

--- a/template/util/col74.md
+++ b/template/util/col74.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 74%. -->
+
+::: {.column width="74%" valign="t"}

--- a/template/util/col75.md
+++ b/template/util/col75.md
@@ -1,4 +1,4 @@
-<!-- Copyright (C) 2023  Kevin Sandom -->
-<!-- Begin a new column. -->
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 75%. -->
 
 ::: {.column width="75%" valign="t"}

--- a/template/util/col76.md
+++ b/template/util/col76.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 76%. -->
+
+::: {.column width="76%" valign="t"}

--- a/template/util/col77.md
+++ b/template/util/col77.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 77%. -->
+
+::: {.column width="77%" valign="t"}

--- a/template/util/col78.md
+++ b/template/util/col78.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 78%. -->
+
+::: {.column width="78%" valign="t"}

--- a/template/util/col79.md
+++ b/template/util/col79.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 79%. -->
+
+::: {.column width="79%" valign="t"}

--- a/template/util/col80.md
+++ b/template/util/col80.md
@@ -1,4 +1,4 @@
-<!-- Copyright (C) 2023  Kevin Sandom -->
-<!-- Begin a new column. -->
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 80%. -->
 
 ::: {.column width="80%" valign="t"}

--- a/template/util/col81.md
+++ b/template/util/col81.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 81%. -->
+
+::: {.column width="81%" valign="t"}

--- a/template/util/col82.md
+++ b/template/util/col82.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 82%. -->
+
+::: {.column width="82%" valign="t"}

--- a/template/util/col83.md
+++ b/template/util/col83.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 83%. -->
+
+::: {.column width="83%" valign="t"}

--- a/template/util/col84.md
+++ b/template/util/col84.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 84%. -->
+
+::: {.column width="84%" valign="t"}

--- a/template/util/col85.md
+++ b/template/util/col85.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 85%. -->
+
+::: {.column width="85%" valign="t"}

--- a/template/util/col86.md
+++ b/template/util/col86.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 86%. -->
+
+::: {.column width="86%" valign="t"}

--- a/template/util/col87.md
+++ b/template/util/col87.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 87%. -->
+
+::: {.column width="87%" valign="t"}

--- a/template/util/col88.md
+++ b/template/util/col88.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 88%. -->
+
+::: {.column width="88%" valign="t"}

--- a/template/util/col89.md
+++ b/template/util/col89.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 89%. -->
+
+::: {.column width="89%" valign="t"}

--- a/template/util/col90.md
+++ b/template/util/col90.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 90%. -->
+
+::: {.column width="90%" valign="t"}

--- a/template/util/col91.md
+++ b/template/util/col91.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 91%. -->
+
+::: {.column width="91%" valign="t"}

--- a/template/util/col92.md
+++ b/template/util/col92.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 92%. -->
+
+::: {.column width="92%" valign="t"}

--- a/template/util/col93.md
+++ b/template/util/col93.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 93%. -->
+
+::: {.column width="93%" valign="t"}

--- a/template/util/col94.md
+++ b/template/util/col94.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 94%. -->
+
+::: {.column width="94%" valign="t"}

--- a/template/util/col95.md
+++ b/template/util/col95.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width 95%. -->
+
+::: {.column width="95%" valign="t"}

--- a/template/util/colTemplate.md
+++ b/template/util/colTemplate.md
@@ -1,0 +1,4 @@
+<!-- Copyright (C) 2024  Kevin Sandom -->
+<!-- Begin a new column of width number%. -->
+
+::: {.column width="number%" valign="t"}

--- a/template/util/generateCols.sh
+++ b/template/util/generateCols.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Generate column sizes.
+
+for i in {5..9}; do
+    echo $i
+    sed "s/number/$i/g" colTemplate.md > "col0$i.md"
+done
+
+
+for i in {10..95}; do
+    echo $i
+    sed "s/number/$i/g" colTemplate.md > "col$i.md"
+done
+
+


### PR DESCRIPTION
From the documentation:

> Without doing anything, variants will be built in the current directory, and custom variants will be built in the custom directory.
> 
> But if you put a symlink to your desired directory within the `outs/` directory, and name it exactly the same as a specific variant, that variant will always be built in that destination directory.
> 
> ## Why?
> 
> Example: In my build setup, I have a directory per job that I want to apply for. I want the built CV to go directly into that directory, and have old versions managed in there as well.
> 
> This will also work for normal variants. Although I haven't yet thought of a good use-case for that.