### PR TITLE
Add noLinks

### DIFF
--- a/bin/cvCompile
+++ b/bin/cvCompile
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Compile markdown into a single markdown file.
-# Copyright (C) 2023  Kevin Sandom
+# Copyright (C) 2023-2024  Kevin Sandom
 
 function listParts
 {
@@ -91,6 +91,20 @@ function doHighlightFilterInclude
 function noComments
 {
     grep -v '^<!--' | sed 's/<!--.*-->//g'
+}
+
+function noNewLines
+{
+    lines="$(grep -v '^ *$')"
+    # echo -e "\n\nLines begin:----------" >&2
+    # echo "$lines" >&2
+    echo "$lines"
+    # echo -e "Lines ended.------------" >&2
+}
+
+function noLinks
+{
+    sed 's/\]([^\[]*)//g;s/\[//g'
 }
 
 function toList
@@ -289,7 +303,7 @@ function doCommand
         ;;
         'filteredIncludeToList')
             # <!-- do filteredIncludeToList skills ~!context!~/skills-dev.md  -->
-            doFilteredInclude "$p1" "$p2" "$p3" | noComments | toList | limit "$p4"
+            doFilteredInclude "$p1" "$p2" "$p3" | noComments | noNewLines | toList | limit "$p4"
         ;;
         'filteredIncludeToBulletedList')
             # <!-- do filteredIncludeToList skills ~!context!~/skills-dev.md  -->
@@ -304,6 +318,10 @@ function doCommand
             local varName="var_$p1"
             export "$varName"="$(echo "$p2" "$p3" "$p4" "$p5" "$p6" "$p7" "$p8" | sed 's/ *--> *$//g')"
             echo "Overrode var $p1 = ${!varName}" >&2
+        ;;
+        'noLinks')
+            # <!-- do noLinks filteredInclude skills ~!context!~/skills-dev.md  -->
+            doCommand "$p1" "$p2" "$p3" "$p4" "$p5" "$p6" "$p7" "$p8" | noLinks
         ;;
         *)
             echo "cvCompile: Unknown command: \"$command\" in \"$line\"" >&2

--- a/doc/howTo/removeLinks.md
+++ b/doc/howTo/removeLinks.md
@@ -1,0 +1,19 @@
+# How to remove links
+
+Sometimes there is a need to remove the hyperlinks in a document (eg you want to colourise the document, but the links will mask that), but it makes sense to keep the links in the original document (eg you want to use the links in another context, or another variant.).
+
+[noLinks](https://github.com/ksandom/cvMangle/blob/main/doc/usingIt.md#nolinks) is a way to strip out links from the output of a given command at compile time, while leaving everything else intact.
+
+## How?
+
+Here is a line from my jobHistory layout. For each job, it includes `skills-communication.md` file from that job (`~!context!~`), and applies the `skills` filter to it.
+
+```
+<!-- do filteredIncludeToList skills ~!context!~/skills-communication.md -->
+```
+
+This line does all of that. But then it strips the links from output of that.
+
+```
+<!-- do noLinks filteredIncludeToList skills ~!context!~/skills-communication.md -->
+```

--- a/doc/usingIt.md
+++ b/doc/usingIt.md
@@ -340,3 +340,15 @@ But we can add the following like to a variant in variants/
 ```
 
 it will now create a heading with the text "Company 1 / Senior admin", but only in that variant.
+
+### noLinks
+
+`noLinks` strips out the hyperlinks from output of a given command.
+
+Simply put the `noLinks` command in front of the command that you are already using. Eg:
+
+```
+<!-- do noLinks filteredIncludeToList skills ~!context!~/skills-communication.md -->
+```
+
+[More detail](https://github.com/ksandom/cvMangle/blob/main/doc/howTo/removeLinks.md).


### PR DESCRIPTION
`noLinks` strips out the hyperlinks from output of a given command.

## Why?

Sometimes there is a need to remove the hyperlinks in a document (eg you want to colourise the document, but the links will mask that), but it makes sense to keep the links in the original document (eg you want to use the links in another context, or another variant.).
